### PR TITLE
AskScript: Make arg types in function definition optional

### DIFF
--- a/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.ask
+++ b/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun(a, b:float,c:int): float {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'any'],
+        ['b', 'float'],
+        ['c', 'int'],
+      ]}
+      returns={'float'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/function05-function_no_arg_type.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.ask
+++ b/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun(a:int, b,c:int): float {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'int'],
+        ['b', 'any'],
+        ['c', 'int'],
+      ]}
+      returns={'float'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/function05b-function_no_arg_type.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.ask
+++ b/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun(a,b,c): float {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'any'],
+        ['b', 'any'],
+        ['c', 'any'],
+      ]}
+      returns={'float'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/function05c-function_no_arg_type.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.ask
+++ b/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun(a , b ,c): float {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'any'],
+        ['b', 'any'],
+        ['c', 'any'],
+      ]}
+      returns={'float'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/function05d-function_no_arg_type_whitespace.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.ask
+++ b/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun( a,b , c ): float {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'any'],
+        ['b', 'any'],
+        ['c', 'any'],
+      ]}
+      returns={'float'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/function05e-function_no_arg_type_whitespace.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.ask
+++ b/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.ask
@@ -1,0 +1,6 @@
+ask {
+    const plus = fun(a:int,b:float,c:int) {
+		return a:plus(b):plus(c)
+	}
+	plus(2, 3.6, 4)
+}

--- a/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.out.tsx
+++ b/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.out.tsx
@@ -1,0 +1,32 @@
+import * as askjsx from '../../../askjsx';
+askjsx;
+
+export const expectedOutput = (
+  <ask>
+    <fun
+      name={'plus'}
+      args={[
+        ['a', 'int'],
+        ['b', 'float'],
+        ['c', 'int'],
+      ]}
+      returns={'any'}
+    >
+      <return
+        value={
+          <call
+            name={'plus'}
+            args={[
+              <call
+                name={'plus'}
+                args={[<ref name={'a'} />, <ref name={'b'} />]}
+              />,
+              <ref name={'c'} />,
+            ]}
+          />
+        }
+      />
+    </fun>
+    <call name={'plus'} args={[2, 3.6, 4]} />
+  </ask>
+);

--- a/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/functions04-function_no_return_type.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/05-functions-methods/program15c-function_def_args.result.tsx.notImplemented
+++ b/src/askscript/__tests__/05-functions-methods/program15c-function_def_args.result.tsx.notImplemented
@@ -1,0 +1,3 @@
+// AskVM Error: 
+//   Over ops limit!
+export const expectedResult = ???;

--- a/src/askscript/__tests__/tools/gen_test_results.ts
+++ b/src/askscript/__tests__/tools/gen_test_results.ts
@@ -65,8 +65,6 @@ async function runFiles(
       `${parts.name}.ts.notImplemented`
     );
 
-    if (parts.base == 'program15c-function_def_args.ask') continue; // This test hangs, TODO(mh): fix and remove this line
-
     // If the output file does not exist, create it from the current AskQL result.
     // Of course later on you need to eyeball it to check whether it looks OK.
     if (

--- a/src/askscript/parser/askscript.grammar.pegjs
+++ b/src/askscript/parser/askscript.grammar.pegjs
@@ -139,7 +139,8 @@ nonEmptyArgList =
     a:arg ',' aL:argList { return aL.unshift(a), aL }
   / a:arg { return [a] }
 
-arg = ws* i:identifier ws* ':' ws* t:type ws* { return new ask.Arg(i, t) }
+arg = ws* i:identifier ws* t:argType? { return new ask.Arg(i, t === null ? ask.anyType : t) }
+argType = ':' ws* t:type ws* { return t }
 
 callArgList = v:valueList { return v }
 valueList = 


### PR DESCRIPTION
Marcin, please note that one .ask program is failing with an error from VM: 'Over ops limit'.
It's a regular program, nothing fancy in it, no loop etc.
Please take a look at it when you have a while.