### PR TITLE
chore(formatting): allow prettier to handle endOfLine characters out of the box

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,6 @@ chatrooms, and mailing lists.
 
     **_Don't forget to replace {yourGithubUsername} with your github username._**
 
-1.  Turn _off_ autocrlf in your Git.  
-    This is advised because some of the test files have Windows line endings on purpose and we would like to keep them there.
-
-        git config core.autocrlf false
-
 1.  Install dependencies:
 
         npm i
@@ -33,7 +28,7 @@ chatrooms, and mailing lists.
 
         npm test
 
-1.  Make your change, with new passing tests. Check out `prettierrc.js`
+1.  Make your change, with new passing tests. Check out `prettier.config.js`
 
 1.  Mention how your changes affect the project to other developers and users in the
     [`NEWS.md`][news] file.

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,8 +5,7 @@ module.exports = {
       options: {
         parser: 'typescript',
         singleQuote: true,
-        // trailingComma: 'es5',
-        // arrowParens: 'always',
+        endOfLine: 'lf',
       },
     },
     {
@@ -15,7 +14,6 @@ module.exports = {
       options: {
         parser: 'askscript',
         plugins: ['./dist/prettier-plugin-askscript'],
-        // semi: true,
       },
     },
   ],


### PR DESCRIPTION
# How to verify

1. Change EndOfLine characters in your IDE
![image](https://user-images.githubusercontent.com/3466388/84192717-b1a09c80-aa9a-11ea-969e-8d835e2f0b8a.png)

1. Pick any file which `prettier` includes
1. add a new line at the end by pressing `return/enter`
1. commit (no changes)

Fixes https://github.com/xFAANG/askql/issues/102