### PR TITLE
fix: remove git add from husky tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "lint-staged": {
     "*": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "bin": {


### PR DESCRIPTION
Closes #109.

I confirmed that no warning is displayed and that prettier correctly runs on commit.