### PR TITLE
fix(playground): reformat initial sample code

### DIFF
--- a/src/playground/views/main.handlebars
+++ b/src/playground/views/main.handlebars
@@ -134,7 +134,9 @@
 											class="btn btn-outline-primary btn-sm hvr-sweep-to-right">Run <i class="fas fa-play fa-sm"
 												aria-hidden="true"></i></a></div>
 								</div>
-								<pre id="editor">ask { hi() } </pre>
+								<pre id="editor">ask {
+	hi()
+}</pre>
 							</div>
 							<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/ace.js" type="text/javascript"
 								charset="utf-8"></script>


### PR DESCRIPTION
Results in:
![image](https://user-images.githubusercontent.com/12752520/87045937-c3d83c80-c1f8-11ea-8d4c-22118d11f733.png)

instead of:
![image](https://user-images.githubusercontent.com/12752520/87045924-c044b580-c1f8-11ea-8d1a-34176c4e3199.png)

Better user experience, easier to delete the line and start coding