### PR TITLE
feat(askvm): toInt

### DIFF
--- a/src/askvm/resources/math/__tests__/toInt.test.ts
+++ b/src/askvm/resources/math/__tests__/toInt.test.ts
@@ -1,0 +1,103 @@
+import { runUntyped } from '../../..';
+import { parse } from '../../../../askcode';
+import * as core from '../../core';
+import { toInt } from '../toInt';
+
+describe('math - toInt', () => {
+  let result: any;
+
+  it(`should return 2 when given 2.3`, async () => {
+    result = await ask(`toInt(2.3)`);
+
+    expect(result).toBe(2);
+  });
+
+  it(`should return 2 when given '2.3'`, async () => {
+    result = await ask(`toInt('2.3')`);
+
+    expect(result).toBe(2);
+  });
+
+  it(`should return 3 when given 2.5`, async () => {
+    result = await ask(`toInt(2.5)`);
+
+    expect(result).toBe(3);
+  });
+
+  it(`should return 3 when given '2.5'`, async () => {
+    result = await ask(`toInt('2.5')`);
+
+    expect(result).toBe(3);
+  });
+
+  it(`should return -2 when given -2.5`, async () => {
+    result = await ask(`toInt(-2.5)`);
+
+    expect(result).toBe(-2);
+  });
+
+  it(`should return -2 when given '-2.5'`, async () => {
+    result = await ask(`toInt('-2.5')`);
+
+    expect(result).toBe(-2);
+  });
+
+  it(`should return -3 when given -2.51`, async () => {
+    result = await ask(`toInt(-2.51)`);
+
+    expect(result).toBe(-3);
+  });
+
+  it(`should return -3 when given '-2.51'`, async () => {
+    result = await ask(`toInt('-2.51')`);
+
+    expect(result).toBe(-3);
+  });
+
+  /*
+  it(`should return 1 when given true`, async () => {
+    result = await ask(`toInt(true)`);
+
+    expect(result).toBe(1);
+  });
+
+  it(`should return 0 when given false`, async () => {
+    result = await ask(`toInt(false)`);
+
+    expect(result).toBe(0);
+  });
+
+  it(`should return 0 when given null`, async () => {
+    result = await ask(`toInt(null)`);
+
+    expect(result).toBe(0);
+  });
+   */
+
+  it('should throw when given non-number string', async () => {
+    await expect(ask(`toInt('4a')`)).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given array', async () => {
+    await expect(ask(`toInt([])`)).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given object', async () => {
+    await expect(ask(`toInt(object('a', 1))`)).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  function ask(code: string) {
+    return runUntyped(
+      {
+        resources: { ...core, toInt },
+      },
+      parse(code)
+    );
+  }
+});

--- a/src/askvm/resources/math/__tests__/toInt.test.ts
+++ b/src/askvm/resources/math/__tests__/toInt.test.ts
@@ -72,21 +72,47 @@ describe('math - toInt', () => {
     expect(result).toBe(0);
   });
 
-  it('should throw when given non-number string', async () => {
+  it('should throw when given "4a"', async () => {
     await expect(e2e(`toInt('4a')`, environment)).rejects.toEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
 
-  it('should throw when given array', async () => {
+  it('should throw when given "abc"', async () => {
+    await expect(e2e(`toInt('abc')`, environment)).rejects.toEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given []', async () => {
     await expect(e2e(`toInt([])`, environment)).rejects.toStrictEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
 
-  it('should throw when given object', async () => {
+  it('should throw when given [1]', async () => {
+    await expect(e2e(`toInt([1])`, environment)).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given [1,2]', async () => {
+    await expect(e2e(`toInt([1,2])`, environment)).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given {a:1}', async () => {
     await expect(
       e2e(`toInt(object('a', 1))`, environment)
+    ).rejects.toStrictEqual(
+      new Error(`toInt is unable to convert given value to Integer.`)
+    );
+  });
+
+  it('should throw when given {a:1, b:2}', async () => {
+    await expect(
+      e2e(`toInt(object('a', 1, 'b', 2))`, environment)
     ).rejects.toStrictEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );

--- a/src/askvm/resources/math/__tests__/toInt.test.ts
+++ b/src/askvm/resources/math/__tests__/toInt.test.ts
@@ -2,77 +2,100 @@ import { runUntyped } from '../../..';
 import { parse } from '../../../../askcode';
 import * as core from '../../core';
 import { toInt } from '../toInt';
+import { resources } from '../../../../askvm';
+import { e2e } from '../../../../utils/tools';
 
 describe('math - toInt', () => {
+  let input: any;
   let result: any;
 
   it(`should return 2 when given 2.3`, async () => {
-    result = await ask(`toInt(2.3)`);
+    given(2.3);
+
+    await execution();
 
     expect(result).toBe(2);
   });
 
   it(`should return 2 when given '2.3'`, async () => {
-    result = await ask(`toInt('2.3')`);
+    given('2.3');
+
+    await execution();
 
     expect(result).toBe(2);
   });
 
   it(`should return 3 when given 2.5`, async () => {
-    result = await ask(`toInt(2.5)`);
+    given(2.5);
+
+    await execution();
 
     expect(result).toBe(3);
   });
 
   it(`should return 3 when given '2.5'`, async () => {
-    result = await ask(`toInt('2.5')`);
+    given('2.5');
+
+    await execution();
 
     expect(result).toBe(3);
   });
 
   it(`should return -2 when given -2.5`, async () => {
-    result = await ask(`toInt(-2.5)`);
+    given(-2.5);
+
+    await execution();
 
     expect(result).toBe(-2);
   });
 
   it(`should return -2 when given '-2.5'`, async () => {
-    result = await ask(`toInt('-2.5')`);
+    given('-2.5');
+
+    await execution();
 
     expect(result).toBe(-2);
   });
 
   it(`should return -3 when given -2.51`, async () => {
-    result = await ask(`toInt(-2.51)`);
+    given(-2.51);
+
+    await execution();
 
     expect(result).toBe(-3);
   });
 
   it(`should return -3 when given '-2.51'`, async () => {
-    result = await ask(`toInt('-2.51')`);
+    given('-2.51');
+
+    await execution();
 
     expect(result).toBe(-3);
   });
 
-  /*
   it(`should return 1 when given true`, async () => {
-    result = await ask(`toInt(true)`);
+    given(true);
+
+    await execution();
 
     expect(result).toBe(1);
   });
 
   it(`should return 0 when given false`, async () => {
-    result = await ask(`toInt(false)`);
+    given(false);
+
+    await execution();
 
     expect(result).toBe(0);
   });
 
   it(`should return 0 when given null`, async () => {
-    result = await ask(`toInt(null)`);
+    given(null);
+
+    await execution();
 
     expect(result).toBe(0);
   });
-   */
 
   it('should throw when given non-number string', async () => {
     await expect(ask(`toInt('4a')`)).rejects.toStrictEqual(
@@ -91,6 +114,16 @@ describe('math - toInt', () => {
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
+
+  function given(value: any) {
+    input = value;
+  }
+
+  async function execution() {
+    const environment = { resources };
+
+    result = await e2e(`toInt(${input})`, environment);
+  }
 
   function ask(code: string) {
     return runUntyped(

--- a/src/askvm/resources/math/__tests__/toInt.test.ts
+++ b/src/askvm/resources/math/__tests__/toInt.test.ts
@@ -1,136 +1,94 @@
-import { runUntyped } from '../../..';
-import { parse } from '../../../../askcode';
-import * as core from '../../core';
-import { toInt } from '../toInt';
 import { resources } from '../../../../askvm';
 import { e2e } from '../../../../utils/tools';
 
 describe('math - toInt', () => {
-  let input: any;
   let result: any;
 
-  it(`should return 2 when given 2.3`, async () => {
-    given(2.3);
+  const environment = { resources };
 
-    await execution();
+  it(`should return 2 when given 2.3`, async () => {
+    result = await e2e(`toInt(2.3)`, environment);
 
     expect(result).toBe(2);
   });
 
   it(`should return 2 when given '2.3'`, async () => {
-    given('2.3');
-
-    await execution();
+    result = await e2e(`toInt('2.3')`, environment);
 
     expect(result).toBe(2);
   });
 
   it(`should return 3 when given 2.5`, async () => {
-    given(2.5);
-
-    await execution();
+    result = await e2e(`toInt(2.5)`, environment);
 
     expect(result).toBe(3);
   });
 
   it(`should return 3 when given '2.5'`, async () => {
-    given('2.5');
-
-    await execution();
+    result = await e2e(`toInt('2.5')`, environment);
 
     expect(result).toBe(3);
   });
 
   it(`should return -2 when given -2.5`, async () => {
-    given(-2.5);
-
-    await execution();
+    result = await e2e(`toInt(-2.5)`, environment);
 
     expect(result).toBe(-2);
   });
 
   it(`should return -2 when given '-2.5'`, async () => {
-    given('-2.5');
-
-    await execution();
+    result = await e2e(`toInt('-2.5')`, environment);
 
     expect(result).toBe(-2);
   });
 
   it(`should return -3 when given -2.51`, async () => {
-    given(-2.51);
-
-    await execution();
+    result = await e2e(`toInt(-2.51)`, environment);
 
     expect(result).toBe(-3);
   });
 
   it(`should return -3 when given '-2.51'`, async () => {
-    given('-2.51');
-
-    await execution();
+    result = await e2e(`toInt('-2.51')`, environment);
 
     expect(result).toBe(-3);
   });
 
   it(`should return 1 when given true`, async () => {
-    given(true);
-
-    await execution();
+    result = await e2e(`toInt(true)`, environment);
 
     expect(result).toBe(1);
   });
 
   it(`should return 0 when given false`, async () => {
-    given(false);
-
-    await execution();
+    result = await e2e(`toInt(false)`, environment);
 
     expect(result).toBe(0);
   });
 
   it(`should return 0 when given null`, async () => {
-    given(null);
-
-    await execution();
+    result = await e2e(`toInt(null)`, environment);
 
     expect(result).toBe(0);
   });
 
   it('should throw when given non-number string', async () => {
-    await expect(ask(`toInt('4a')`)).rejects.toStrictEqual(
+    await expect(e2e(`toInt('4a')`, environment)).rejects.toEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
 
   it('should throw when given array', async () => {
-    await expect(ask(`toInt([])`)).rejects.toStrictEqual(
+    await expect(e2e(`toInt([])`, environment)).rejects.toStrictEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
 
   it('should throw when given object', async () => {
-    await expect(ask(`toInt(object('a', 1))`)).rejects.toStrictEqual(
+    await expect(
+      e2e(`toInt(object('a', 1))`, environment)
+    ).rejects.toStrictEqual(
       new Error(`toInt is unable to convert given value to Integer.`)
     );
   });
-
-  function given(value: any) {
-    input = value;
-  }
-
-  async function execution() {
-    const environment = { resources };
-
-    result = await e2e(`toInt(${input})`, environment);
-  }
-
-  function ask(code: string) {
-    return runUntyped(
-      {
-        resources: { ...core, toInt },
-      },
-      parse(code)
-    );
-  }
 });

--- a/src/askvm/resources/math/toInt.ts
+++ b/src/askvm/resources/math/toInt.ts
@@ -3,6 +3,9 @@ import { resource, int } from '../../lib';
 export const toInt = resource({
   type: int,
   async resolver(value: any) {
-    return Number(value);
+    if ((typeof value === 'object' && value !== null) || isNaN(value)) {
+      throw new Error('toInt is unable to convert given value to Integer.');
+    }
+    return Math.round(value);
   },
 });


### PR DESCRIPTION
- Will resolve https://github.com/xFAANG/askql/issues/269#issuecomment-660027793

@czerwinskilukasz1 

Main issues I have;

- Passing `true`, `false` or `null` to `toInt` results in the arg being converted into an instance of `AskCode` e.g. `toInt(false)` --> `false` becomes `AskCode { name: false, params: undefined }` inside of `toInt`
- I assume I should not have to do something like

```
let val;
if (value instanceof AskCode) {
     val = value.name;
}
return Math.round(val);
```

- I guess there is some step I am missing - if you could advise would be great!
- Also not sure if `toInt(object('a', 1))` is the correct way to test `toInt({a: 1})`